### PR TITLE
destructor incorrectly clears $@ upon successful removal of temp directory

### DIFF
--- a/lib/File/pushd.pm
+++ b/lib/File/pushd.pm
@@ -101,8 +101,13 @@ sub DESTROY {
     chdir $orig if $orig; # should always be so, but just in case...
     if ( $self->{_tempd} &&
         !$self->{_preserve} ) {
-        eval { rmtree( $self->{_pushd} ) };
-        carp $@ if $@;
+	# don't destroy existing $@ if there is no error.
+	my $err = do {
+	    local $@;
+	    eval { rmtree( $self->{_pushd} ) };
+	    $@;
+	};
+        carp $err if $err;
     }
 }
 

--- a/t/exception.t
+++ b/t/exception.t
@@ -1,0 +1,21 @@
+#! perl
+
+use Test::More tests => 2;
+
+use File::Spec::Functions qw( curdir );
+
+BEGIN { use_ok( 'File::pushd' ); }
+
+eval {
+
+     my $dir = tempd;
+
+     die( "error\n" );
+
+
+};
+
+my $err = $@;
+
+is( $err, "error\n", "destroy did not clobber \$@\n" );
+


### PR DESCRIPTION
The destructor cleared $@ even upon success.  If the destructor was called in the process of handling an exception, the exception was cleared and the code which handled the exception was passed an empty $@.
