### PR TITLE
Doesn't install on MSWin32 if current directory (or parent) name starts with o

### DIFF
--- a/t/File_pushd.t
+++ b/t/File_pushd.t
@@ -156,6 +156,7 @@ ok( rmtree($temp_dir), "temporary directory manually cleaned up" );
 
 my $program_file = File::Temp->new();
 my $lib          = absdir("lib");
+$lib =~ s{\\}{/}g;
 
 print {$program_file} <<"END_PROGRAM";
 use lib "$lib";


### PR DESCRIPTION
Hi there, this patch fixes this failure for me:

http://www.cpantesters.org/cpan/report/02b244fe-73bd-1014-9c15-1273adef1522

I am seeing this failure because the path that I am installing in has a directory that starts with the letter o, and "\o" has special meaning.
