### PR TITLE
Travis-CI: add perl 5.20-5.24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ script: prove -lr t
 install:
   - cpanm -n -q --skip-satisfied --installdeps .
 perl:
-  - "5.19"
+  - "5.24"
+  - "5.22"
+  - "5.20"
   - "5.18"
   - "5.16"
   - "5.14"


### PR DESCRIPTION
Add latest stable perl to Travis-CI configuration.
Remove perl 5.19.