### PR TITLE
Tidy

### DIFF
--- a/lib/File/pushd.pm
+++ b/lib/File/pushd.pm
@@ -26,9 +26,9 @@ use overload
 
 sub pushd {
     # Called in void context?
-    unless (defined wantarray) {
-        warnings::warnif(void => 'Useless use of File::pushd::pushd in void context');
-        return
+    unless ( defined wantarray ) {
+        warnings::warnif( void => 'Useless use of File::pushd::pushd in void context' );
+        return;
     }
 
     my ( $target_dir, $options ) = @_;
@@ -77,9 +77,9 @@ sub pushd {
 
 sub tempd {
     # Called in void context?
-    unless (defined wantarray) {
-        warnings::warnif(void => 'Useless use of File::pushd::tempd in void context');
-        return
+    unless ( defined wantarray ) {
+        warnings::warnif( void => 'Useless use of File::pushd::tempd in void context' );
+        return;
     }
 
     my ($options) = @_;
@@ -116,7 +116,7 @@ sub DESTROY {
     my ($self) = @_;
     my $orig = $self->{_original};
     chdir $orig if $orig; # should always be so, but just in case...
-    if ( $self->{_tempd}
+    if (   $self->{_tempd}
         && $self->{_owner} == $$
         && !$self->{_preserve} )
     {

--- a/t/File_pushd.t
+++ b/t/File_pushd.t
@@ -230,11 +230,11 @@ ok( -e $expected_dir, "original directory not removed" );
 # Test removing temp directory by owner process
 #--------------------------------------------------------------------------#
 if ( $Config{d_fork} ) {
-    my $new_dir = tempd();
+    my $new_dir  = tempd();
     my $temp_dir = "$new_dir";
-    my $pid = fork;
+    my $pid      = fork;
     die "Can't fork: $!" unless defined $pid;
-    if ($pid == 0) {
+    if ( $pid == 0 ) {
         exit;
     }
     wait;

--- a/tidyall.ini
+++ b/tidyall.ini
@@ -3,3 +3,4 @@
 ; run "tidyall -g" to tidy only files modified from git
 [PerlTidy]
 select = {lib,t}/**/*.{pl,pm,t}
+argv = --profile=$ROOT/.perltidyrc


### PR DESCRIPTION
The `tidyall.ini` configuration file wasn't using the `.perltidyrc` file in the source directory.  Do so, and then run tidy to clean up the code.