### PR TITLE
Can't push a directory named '0' 

### DIFF
--- a/lib/File/pushd.pm
+++ b/lib/File/pushd.pm
@@ -26,9 +26,9 @@ use overload
 
 sub pushd {
     # Called in void context?
-    unless (defined wantarray) {
-        warnings::warnif(void => 'Useless use of File::pushd::pushd in void context');
-        return
+    unless ( defined wantarray ) {
+        warnings::warnif( void => 'Useless use of File::pushd::pushd in void context' );
+        return;
     }
 
     my ( $target_dir, $options ) = @_;
@@ -77,9 +77,9 @@ sub pushd {
 
 sub tempd {
     # Called in void context?
-    unless (defined wantarray) {
-        warnings::warnif(void => 'Useless use of File::pushd::tempd in void context');
-        return
+    unless ( defined wantarray ) {
+        warnings::warnif( void => 'Useless use of File::pushd::tempd in void context' );
+        return;
     }
 
     my ($options) = @_;
@@ -116,7 +116,7 @@ sub DESTROY {
     my ($self) = @_;
     my $orig = $self->{_original};
     chdir $orig if $orig; # should always be so, but just in case...
-    if ( $self->{_tempd}
+    if (   $self->{_tempd}
         && $self->{_owner} == $$
         && !$self->{_preserve} )
     {

--- a/lib/File/pushd.pm
+++ b/lib/File/pushd.pm
@@ -47,7 +47,7 @@ sub pushd {
     }
 
     my $tainted_dest;
-    eval { $tainted_dest = $target_dir ? abs_path($target_dir) : $orig };
+    eval { $tainted_dest = defined $target_dir ? abs_path($target_dir) : $orig };
     croak "Can't locate absolute path for $target_dir: $@" if $@;
 
     my $dest;

--- a/t/File_pushd.t
+++ b/t/File_pushd.t
@@ -230,11 +230,11 @@ ok( -e $expected_dir, "original directory not removed" );
 # Test removing temp directory by owner process
 #--------------------------------------------------------------------------#
 if ( $Config{d_fork} ) {
-    my $new_dir = tempd();
+    my $new_dir  = tempd();
     my $temp_dir = "$new_dir";
-    my $pid = fork;
+    my $pid      = fork;
     die "Can't fork: $!" unless defined $pid;
-    if ($pid == 0) {
+    if ( $pid == 0 ) {
         exit;
     }
     wait;

--- a/t/regressions/leading_zero.t
+++ b/t/regressions/leading_zero.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Test::More 0.96;
+use File::pushd;
+use Cwd;
+use File::Spec::Functions 'catdir';
+
+{
+    my $temp = tempd();
+    mkdir '0' or die("unable to create 0 directory\n");
+
+    my $parent = "$temp";
+    my $child  = pushd('0');
+
+    is( "$child", catdir( "$parent", '0' ) );
+}
+
+done_testing;

--- a/tidyall.ini
+++ b/tidyall.ini
@@ -3,3 +3,4 @@
 ; run "tidyall -g" to tidy only files modified from git
 [PerlTidy]
 select = {lib,t}/**/*.{pl,pm,t}
+argv = --profile=$ROOT/.perltidyrc


### PR DESCRIPTION
A boolean test for a defined `$target_dir` checked the truthfulness of `$target_dir` (e.g.  `$target_dir ? ... : ...`) rather than whether it was defined.

This is based off  PR #14  so that the code is properly tidied.